### PR TITLE
Add notifications for Barns and Coops

### DIFF
--- a/StardewNewsFeed/EntryPoint.cs
+++ b/StardewNewsFeed/EntryPoint.cs
@@ -30,11 +30,12 @@ namespace StardewNewsFeed {
             }
 
             if (_modConfig.CoopCheckEnabled) {
-                helper.Events.GameLoop.DayStarted += (s, e) => _gameService.CheckFarmBuildings<Coop>();
+                helper.Events.GameLoop.DayStarted += (s, e) => _gameService.CheckFarmBuildingsForHarvastableItems<Coop>();
             }
 
             if (_modConfig.BarnCheckEnabled) {
-                helper.Events.GameLoop.DayStarted += (s, e) => _gameService.CheckFarmBuildings<Barn>();
+                helper.Events.GameLoop.DayStarted += (s, e) => _gameService.CheckBarnForAnimalProducts();
+                helper.Events.GameLoop.DayStarted += (s, e) => _gameService.CheckFarmBuildingsForHarvastableItems<Barn>();
             }
 
             if (_modConfig.BirthdayCheckEnabled) {

--- a/StardewNewsFeed/Extensions/FarmAnimalExtensions.cs
+++ b/StardewNewsFeed/Extensions/FarmAnimalExtensions.cs
@@ -1,0 +1,9 @@
+using StardewValley;
+
+namespace StardewNewsFeed.Extensions {
+    public static class AnimalExtensions {
+        public static bool HasAvailableProduce(this FarmAnimal @this) {
+            return @this?.currentProduce?.Value > 0;
+        }
+    }
+}

--- a/StardewNewsFeed/Services/IGameService.cs
+++ b/StardewNewsFeed/Services/IGameService.cs
@@ -6,8 +6,9 @@ namespace StardewNewsFeed.Services {
         void CheckGreenhouse();
         void CheckCellar();
         void CheckShed();
+        void CheckBarnForAnimalProducts();
         void CheckLocationForBirthdays(ILocation location);
-        void CheckFarmBuildings<T>() where T : StardewValley.Buildings.Building;
+        void CheckFarmBuildingsForHarvastableItems<T>() where T : StardewValley.Buildings.Building;
         void CheckSilos();
     }
 }

--- a/StardewNewsFeed/StardewNewsFeed.csproj
+++ b/StardewNewsFeed/StardewNewsFeed.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -31,6 +31,7 @@
     <Reference Include="System" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Extensions\FarmAnimalExtensions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="EntryPoint.cs" />
     <Compile Include="ModConfig.cs" />

--- a/StardewNewsFeed/Wrappers/Farm.cs
+++ b/StardewNewsFeed/Wrappers/Farm.cs
@@ -1,19 +1,30 @@
-﻿
 using System.Collections.Generic;
 using System.Linq;
 using StardewModdingAPI;
+using StardewNewsFeed.Extensions;
 using StardewValley;
+using StardewValley.Buildings;
 
 namespace StardewNewsFeed.Wrappers {
     public class Farm : IFarm {
-
         private readonly StardewValley.Farm _farm;
+
+        public IEnumerable<FarmAnimal> BarnAnimalsWithAvailableProduce {
+            get {
+                var list = Game1.getFarm().animals.Values.ToList();
+                foreach (Building building in Game1.getFarm().buildings.Where(_ => _.buildingType.Value.EndsWith("Barn"))) {
+                    if (building.indoors.Value != null && building.indoors.Value.GetType() == typeof(AnimalHouse))
+                        list.AddRange(((AnimalHouse)building.indoors.Value).animals.Values.ToList());
+                }
+                return list.Where(_ => _.HasAvailableProduce());
+            }
+        }
 
         public Farm(StardewValley.Farm farm) {
             _farm = farm;
         }
 
-        public IList<ILocation> GetBuildings<T>(ITranslationHelper translationHelper) {
+        public IEnumerable<ILocation> GetBuildings<T>(ITranslationHelper translationHelper) {
             var buildings = _farm.buildings
                 .Select(b => b.indoors.Value)
                 .Where(i => i is T)
@@ -27,6 +38,5 @@ namespace StardewNewsFeed.Wrappers {
 
             return buildings.Select(b => new Location(b, translationHelper) as ILocation).ToList();
         }
-
     }
 }

--- a/StardewNewsFeed/Wrappers/IFarm.cs
+++ b/StardewNewsFeed/Wrappers/IFarm.cs
@@ -1,5 +1,6 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using StardewModdingAPI;
+using StardewValley;
 
 namespace StardewNewsFeed.Wrappers {
 
@@ -7,6 +8,7 @@ namespace StardewNewsFeed.Wrappers {
     /// Wrapper for StardewValley.Farm
     /// </summary>
     public interface IFarm {
-        IList<ILocation> GetBuildings<T>(ITranslationHelper translationHelper);
+        IEnumerable<FarmAnimal> BarnAnimalsWithAvailableProduce { get; }
+        IEnumerable<ILocation> GetBuildings<T>(ITranslationHelper translationHelper);
     }
 }

--- a/StardewNewsFeed/Wrappers/StardewObject.cs
+++ b/StardewNewsFeed/Wrappers/StardewObject.cs
@@ -1,23 +1,46 @@
 ﻿using System;
+using System.Linq;
 using Netcode;
+using StardewValley.Objects;
+using StardewValley.TerrainFeatures;
 using Object = StardewValley.Object;
 
 namespace StardewNewsFeed.Wrappers {
+    interface IAmHarvestable {
+        bool readyForHarvest { get; }
+    }
+    
     public class StardewObject : IStardewObject {
-
-        private readonly Object _object;
+        private readonly object _object;
+        private const int AutoGrabberSheetIndex = 165;
 
         public StardewObject(object obj) {
-            if(obj is Object) {
-                _object = obj as Object;
-            } else {
-                throw new ArgumentException($"{nameof(obj)} is not a valid StardewValley.Object");
-            }
+            _object = obj;
         }
 
         public bool IsReadyForHarvest() {
-            return (_object.readyForHarvest == new NetBool(true))
-                || _object.isAnimalProduct(); // animal products laying around are always ready for harvest
+            if (_object is HoeDirt hoeDirt) {
+                return hoeDirt.readyForHarvest();
+            }
+
+            if (!(_object is Object)) {
+                throw new ArgumentException($"{nameof(_object)} is not a valid StardewValley.Object");
+            }
+
+            var stardewObject = (Object) _object;
+            var itemIsReadyForHarvest = (stardewObject.readyForHarvest == new NetBool(true))
+                || stardewObject.isAnimalProduct(); // animal products laying around are always ready for harvest
+            if (itemIsReadyForHarvest) {
+                return true;
+            }
+
+            var itemIsAutoGrabber = stardewObject.ParentSheetIndex == AutoGrabberSheetIndex;
+            if (!itemIsAutoGrabber) {
+                return false;
+            }
+
+            var chest = stardewObject.heldObject.Value as Chest;
+            return chest?.items?.Any() ?? false;
         }
     }
 }

--- a/StardewNewsFeed/i18n/default.json
+++ b/StardewNewsFeed/i18n/default.json
@@ -1,6 +1,8 @@
 {
     "news-feed.birthday-notice": "Today is {{npcName}}'s birthday. Don't forget to give them a gift!",
     "news-feed.harvest-items-found-in-location-notice": "There are {{numberOfItems}} items ready to harvest in the {{locationName}}!",
+    "news-feed.harvest-animals-found-in-location-notice.singular": "There is 1 animal with available produce in the {{locationName}} (You'll need: {{toolsNeededForProduce}})!",
+    "news-feed.harvest-animals-found-in-location-notice.plural": "There are {{numberOfItems}} animals with available produce in the {{locationName}} (You'll need: {{toolsNeededForProduce}})!",
     "news-feed.bats-dropped-fruit-notice": "The bats have brought you some fruit!",
     "news-feed.cave-display-name": "Farm Cave",
     "news-feed.silo-low-notice": "Your silos are low ({{piecesOfHay}}/{{maxCapacity}})"


### PR DESCRIPTION
Prior to this change, we were only notifying the user about items that
were available for harvest in the barn (cheese press). This change adds
checks for any livestock that have produce available for harvesting, and
list which tools the user should take with them that day.

Issue: #6 